### PR TITLE
Update waitForKeyword.js

### DIFF
--- a/node-red/nodes/pepper/waitForKeyword/waitForKeyword.js
+++ b/node-red/nodes/pepper/waitForKeyword/waitForKeyword.js
@@ -65,6 +65,7 @@ module.exports = RED => {
             const output = new Array(config.keywords.length).fill(null);
             const index = config.keywords.indexOf(keyword);
 
+            node.waitingNode.payload = keyword;
             output[index] = node.waitingNode;
 
             node.send(output);


### PR DESCRIPTION
Documentation says that waitForKeyword returns the recognized keyword as payload. This the fix for that.