### PR TITLE
Add Node-RED node for Pepper camera capture API (interaction)

### DIFF
--- a/node-red/nodes/pepper/makePicture/locales/de-DE/makePicture.html
+++ b/node-red/nodes/pepper/makePicture/locales/de-DE/makePicture.html
@@ -1,0 +1,3 @@
+<script type="text/markdown" data-help-name="Make Picture">
+Macht zum Aufrufzeitpunkt ein Foto
+</script>

--- a/node-red/nodes/pepper/makePicture/locales/de-DE/makePicture.json
+++ b/node-red/nodes/pepper/makePicture/locales/de-DE/makePicture.json
@@ -1,0 +1,8 @@
+{
+    "MakePicture": {
+        "takingPicture": "Mache Foto",
+        "bottom": "Unten",
+        "top": "Oben",
+        "outputFormat": "Ausgabeformat"
+    }
+}

--- a/node-red/nodes/pepper/makePicture/locales/en-US/makePicture.html
+++ b/node-red/nodes/pepper/makePicture/locales/en-US/makePicture.html
@@ -1,0 +1,3 @@
+<script type="text/markdown" data-help-name="Make Picture">
+Takes a photo at the time of the call
+</script>

--- a/node-red/nodes/pepper/makePicture/locales/en-US/makePicture.json
+++ b/node-red/nodes/pepper/makePicture/locales/en-US/makePicture.json
@@ -1,0 +1,8 @@
+{
+    "MakePicture": {
+      "takingPicture": "Taking Picture",
+      "bottom": "Bottom",
+      "top": "Top",
+      "outputFormat": "Output format"
+    }
+}

--- a/node-red/nodes/pepper/makePicture/makePicture.html
+++ b/node-red/nodes/pepper/makePicture/makePicture.html
@@ -1,0 +1,41 @@
+<script type="text/javascript">
+    RED.nodes.registerType("Make Picture", {
+        category: "Pepper",
+        color: "#FFCC66",
+        defaults: {
+            camera: {value:"0", required:true},
+            output: {value:"base64", required:true},
+        },
+        inputs: 1,
+        outputs: 1,
+        icon: "font-awesome/fa-camera",
+        label: () => {
+        	return this.name
+        },
+        oneditprepare: function() {
+            $("#node-input-camera").val(this.camera);
+            $("#node-input-output").val(this.output);
+        }
+    });
+</script>
+
+<script type="text/html" data-template-name="Make Picture">
+    <div class="form-row">
+        <label for="node-input-camera">
+            <span data-i18n="MakePicture.takingPicture"></span>
+        </label>
+        <select id="node-input-camera">
+            <option value="0" data-i18n="MakePicture.bottom"></option>
+            <option value="1" data-i18n="MakePicture.top"></option>    
+        </select>
+    </div>
+    <div class="form-row">
+        <label for="node-input-output">
+            <span data-i18n="MakePicture.outputFormat"></span>
+        </label>
+        <select id="node-input-output">
+            <option value="raw">Raw</option>
+            <option value="base64">Base64</option>    
+        </select>
+    </div>
+</script>

--- a/node-red/nodes/pepper/makePicture/makePicture.js
+++ b/node-red/nodes/pepper/makePicture/makePicture.js
@@ -1,0 +1,34 @@
+module.exports = RED => {
+    function MakePictureNode(config) {
+        RED.nodes.createNode(this, config);
+        const node = this;
+		const axios = require('axios');
+
+        node.camera = config.camera || '0';  // Default to bottom if not set
+        node.output = config.output || 'base64';  // Default to base64 if not set
+
+        node.on('input', function(msg) {
+            var camera = node.camera;
+            var output = node.output;
+            var path = node.path;
+
+            var url = `http://localhost:5000/pepper/camera/?cameraIndex=${camera}&encoding=${output}`;
+			node.status({ fill: "yellow", shape: "dot", text: "requesting" });
+
+            axios.get(url)
+                .then(response => {
+                    msg.payload = response.data;
+					node.status({ fill: "green", shape: "dot", text: "success" });
+                    node.send(msg);
+                })
+                .catch(error => {
+                    node.error("Error: " + error);
+                    msg.payload = {error: error.message};
+					node.status({ fill: "red", shape: "ring", text: "error" });
+                    node.send(msg);
+                });
+        });
+
+    }
+    RED.nodes.registerType("Make Picture", MakePictureNode);
+}


### PR DESCRIPTION
- Created a new Node-RED node to interact with the Pepper camera capture API
- Implemented functionality to send requests to the /pepper/camera endpoint
- Added configuration options for camera index and encoding parameters
